### PR TITLE
Do not unregister listeners on unexpected data

### DIFF
--- a/syslog/OpenOS/etc/rc.d/syslogd.lua
+++ b/syslog/OpenOS/etc/rc.d/syslogd.lua
@@ -69,15 +69,15 @@ local function wentry(_,msg,level,service,host)
 end
 
 local function remote_listener(_,from,port,data)
- if port ~= cfg.port then return false end
+ if port ~= cfg.port then return end
  local service, level, msg = data:match("(.-)\t(%d)\t(.+)")
- if not service or not level or not msg then return false end
+ if not service or not level or not msg then return end
  msg, level, service = tostring(msg),tonumber(level),tostring(service)
  wentry(nil,msg,level,service,from)
 end
 
 local function local_listener(_,msg,level,service)
- if not service or not level or not msg then return false end
+ if not service or not level or not msg then return end
  msg, level, service = tostring(msg),tonumber(level),tostring(service)
  wentry(nil,msg,level,service,hostname)
 end


### PR DESCRIPTION
If a registered event listener callback returns `false`, the listener is unregistered. A network packet arriving on a different port, or a message with a missing part, should not cause the syslog system to shut down. Return `nil` instead of `false` if those sanity checks fail, to keep the listener registered.