### PR TITLE
Fix registering the wrong listener

### DIFF
--- a/syslog/OpenOS/etc/rc.d/syslogd.lua
+++ b/syslog/OpenOS/etc/rc.d/syslogd.lua
@@ -85,7 +85,7 @@ end
 function start()
  reload()
  if #listeners > 0 then return end
- event.listen("syslog",wentry)
+ event.listen("syslog",local_listener)
  listeners[#listeners+1] = {"syslog",local_listener}
  if havenet and cfg.receive then
   event.listen("net_msg",remote_listener)


### PR DESCRIPTION
The `local_listener` function is obviously intended to be used as the event listener for locally pushed `syslog` events, to do preliminary sanity checks and type conversions before calling `wentry`. However, it was not actually registered as such. Not only does this mean the sanity checks and type conversions could be skipped, it also means that `rc syslogd stop` would not work because `wentry` was actually registered as a listener while `local_listener` was pushed in the `listeners` table, so `event.ignore` would be passed the wrong value and would not unregister `wentry`.