### PR TITLE
Fix: responce was interpritated as function call

### DIFF
--- a/RPC/OpenOS/usr/bin/exportall.lua
+++ b/RPC/OpenOS/usr/bin/exportall.lua
@@ -2,12 +2,9 @@ local component = require "component"
 local r2r = require "r2r"
 local tA = {...}
 
-if #tA < 1 then
- print("Usage: exportcomponent <component address> [component address...]")
-end
 
-for k,v in ipairs(tA) do
- local px = component.proxy(component.get(v))
+for k,v in component.list() do
+ local px = component.proxy(component.get(k))
  print(px.type.."_"..px.address)
  for l,m in pairs(px) do
   r2r.register(px.type.."_"..px.address.."_"..l,m)

--- a/RPC/OpenOS/usr/bin/importall.lua
+++ b/RPC/OpenOS/usr/bin/importall.lua
@@ -31,5 +31,6 @@ for k,v in cm do
     error("no such remote component: "..addr)
     end
     vcomponent.register(faddr or addr, ctype, px)
+    os.sleep(2)
 end
 

--- a/RPC/OpenOS/usr/bin/importall.lua
+++ b/RPC/OpenOS/usr/bin/importall.lua
@@ -8,11 +8,11 @@ if #tA < 1 then
  return
 end
 
-local components = r2r.call(host,"listcomponents")
+local cm = r2r.call(host,"listcomponents")
 
-for k,v in pairs(components) do
-    ctype = k
-    addr = v
+for k,v in cm do
+    ctype = v
+    addr = k
     local saddr = addr:gsub("%-","%%-")
     if addr:len() < 36 then
     local flist = r2r.call(host,"list")
@@ -31,6 +31,5 @@ for k,v in pairs(components) do
     error("no such remote component: "..addr)
     end
     vcomponent.register(faddr or addr, ctype, px)
-
 end
 

--- a/RPC/OpenOS/usr/bin/importall.lua
+++ b/RPC/OpenOS/usr/bin/importall.lua
@@ -1,0 +1,36 @@
+local vcomponent = require "vcomponent"
+local r2r = require "r2r"
+local tA = {...}
+local host = tA[1]
+
+if #tA < 1 then
+ print("Usage: importcomponent <host>")
+ return
+end
+
+local components = r2r.call(host,"listcomponents")
+
+for k,v in pairs(components) do
+    ctype = k
+    addr = v
+    local saddr = addr:gsub("%-","%%-")
+    if addr:len() < 36 then
+    local flist = r2r.call(host,"list")
+    for k,v in pairs(flist) do
+    faddr = v:match(ctype.."_("..saddr..".*)_") or faddr
+    end
+    end
+    print(faddr)
+    saddr = (faddr or addr):gsub("%-","%%-")
+    local px = r2r.proxy(host,ctype.."_"..saddr..".*_")
+    local mc = 0
+    for k,v in pairs(px) do
+    mc = mc + 1
+    end
+    if mc < 1 then
+    error("no such remote component: "..addr)
+    end
+    vcomponent.register(faddr or addr, ctype, px)
+
+end
+

--- a/RPC/OpenOS/usr/bin/importcomponent.lua
+++ b/RPC/OpenOS/usr/bin/importcomponent.lua
@@ -1,5 +1,5 @@
 local vcomponent = require "vcomponent"
-local rpc = require "rpc"
+local r2r = require "r2r"
 local tA = {...}
 local host, ctype, addr = tA[1], tA[2], tA[3]
 
@@ -11,14 +11,14 @@ end
 local saddr = addr:gsub("%-","%%-")
 
 if addr:len() < 36 then
- local flist = rpc.call(host,"list")
+ local flist = r2r.call(host,"list")
  for k,v in pairs(flist) do
   faddr = v:match(ctype.."_("..saddr..".*)_") or faddr
  end
 end
 print(faddr)
 saddr = (faddr or addr):gsub("%-","%%-")
-local px = rpc.proxy(host,ctype.."_"..saddr..".*_")
+local px = r2r.proxy(host,ctype.."_"..saddr..".*_")
 local mc = 0
 for k,v in pairs(px) do
  mc = mc + 1

--- a/RPC/OpenOS/usr/lib/r2r.lua
+++ b/RPC/OpenOS/usr/lib/r2r.lua
@@ -1,6 +1,6 @@
 r2r = {}
 r2r.buffer = {}
-r2r.chunksize = 4000
+r2r.chunksize = 1000
 r2r.initalized = false
 r2r.fn = {}
 

--- a/RPC/OpenOS/usr/lib/r2r.lua
+++ b/RPC/OpenOS/usr/lib/r2r.lua
@@ -1,0 +1,115 @@
+r2r = {}
+r2r.buffer = {}
+r2r.chunksize = 4000
+r2r.initalized = false
+r2r.fn = {}
+
+local rpc = require("rpc")
+local serial = require "serialization"
+local component = require("component")
+
+function r2r.fn.list()
+    local rt = {}
+    for k,v in pairs(r2r.fn) do
+        rt[#rt + 1] = k
+    end
+    return rt
+end
+
+function r2r.fn.listcomponents()
+    return component.list()
+end
+
+function r2r.init()
+    rpc.register("createendpoint", function()
+        local key = require("uuid").next()
+        r2r.buffer[key] = {}
+        return key
+    end)
+
+    rpc.register("record", function(data, key)
+        r2r.buffer[key][#r2r.buffer[key] + 1] = data
+        return true
+    end)
+    
+    rpc.register("call", function(function_name, key)
+        local data = ""
+        for i = 1, #r2r.buffer[key] do
+            data = data .. r2r.buffer[key][i]
+        end
+        local deserialized = serial.unserialize(data)
+        local result = r2r.fn[function_name](table.unpack(deserialized))
+        local serialized_result = serial.serialize({result})
+        local chunk_count = #serialized_result // r2r.chunksize
+        if #serialized_result % r2r.chunksize ~= 0 then
+            chunk_count = chunk_count + 1
+        end
+        r2r.buffer[key]["result"] = {}
+        for i = 1, chunk_count do
+            r2r.buffer[key]["result"][i] = serialized_result:sub((i - 1) * r2r.chunksize + 1, i * r2r.chunksize)
+        end
+        return true
+    end)
+
+    rpc.register("getresultpart", function(key, id)
+        return r2r.buffer[key]["result"][id]
+    end)
+
+    rpc.register("getchunkcount", function(key)
+        return #r2r.buffer[key]["result"]
+    end)
+
+    rpc.register("removeendpoint", function(key)
+        r2r.buffer[key] = nil
+    end)
+
+    r2r.initalized = true
+end 
+
+function r2r.call(host,function_name, ...)
+    local key = rpc.call(host,"createendpoint")
+    local serialized_args = serial.serialize({...})
+    local chunk_count = #serialized_args // r2r.chunksize
+    if #serialized_args % r2r.chunksize ~= 0 then
+        chunk_count = chunk_count + 1
+    end
+    for i = 1, chunk_count do
+        local chunk = serialized_args:sub((i - 1) * r2r.chunksize + 1, i * r2r.chunksize)
+        rpc.call(host,"record", chunk, key)
+    end
+    rpc.call(host,"call", function_name, key)
+    local result_chunk_count = rpc.call(host,"getchunkcount", key)
+    local result = ""
+    for i = 1, result_chunk_count do
+        result = result .. rpc.call(host,"getresultpart", key, i)
+    end
+    rpc.call(host,"removeendpoint", key)
+    return table.unpack(serial.unserialize(result))
+end
+
+
+function r2r.proxy(hostname,filter)
+    filter=(filter or "").."(.+)"
+    local fnames = r2r.call(hostname,"list")
+    if not fnames then return false end
+    local rt = {}
+    for k,v in pairs(fnames) do
+        fv = v:match(filter)
+        if fv then
+            rt[fv] = function(...)
+                return r2r.call(hostname,v,...)
+            end
+        end
+    end
+    return rt
+end
+
+
+function r2r.register(name,fn)
+    if not r2r.initalized then
+        r2r.init()
+    end
+    r2r.fn[name] = fn
+end
+
+return r2r

--- a/RPC/OpenOS/usr/lib/rpc.lua
+++ b/RPC/OpenOS/usr/lib/rpc.lua
@@ -62,6 +62,9 @@ function rpc.register(name,fn)
   event.listen("net_msg",function(_, from, port, data)
    if port == rpc.port then
     local rpcrq = serial.unserialize(data)
+    if #rpcrq ~= 3 then
+     return
+    end
     local rpcn, rpcid = table.remove(rpcrq,1), table.remove(rpcrq,1)
     if rpcf[rpcn] and isPermitted(from,rpcn) then
      local rt = {pcall(rpcf[rpcn],table.unpack(rpcrq))}

--- a/programs.cfg
+++ b/programs.cfg
@@ -191,7 +191,10 @@
   files = {
    ["master/RPC/OpenOS/usr/bin/importcomponent.lua"] = "/bin",
    ["master/RPC/OpenOS/usr/bin/exportcomponent.lua"] = "/bin",
+   ["master/RPC/OpenOS/usr/bin/exportall.lua"] = "/bin",
+   ["master/RPC/OpenOS/usr/bin/importall.lua"] = "/bin",
    ["master/RPC/OpenOS/usr/lib/rpc.lua"] = "/lib",
+   ["master/RPC/OpenOS/usr/lib/r2r.lua"] = "/lib",
    ["master/RPC/OpenOS/usr/man/rpc"] = "/man",
   },
   dependencies = {

--- a/programs.cfg
+++ b/programs.cfg
@@ -1,5 +1,5 @@
 {
- ["minitel"] = {
+ ["examnes-minitel"] = {
   files = {
    ["master/OpenOS/etc/rc.d/minitel.lua"] = "//etc/rc.d",
    ["master/OpenOS/usr/lib/net.lua"] = "/lib",
@@ -14,13 +14,13 @@
   authors = "Izaya, Skye",
   repo = "tree/master/"
  },
- ["minitel-util"] = {
+ ["examnes-minitel-util"] = {
   files = {
    ["master/util/OpenOS/usr/bin/ping.lua"] = "/bin",
    ["master/util/OpenOS/usr/bin/mtcfg.lua"] = "/bin",
   },
   dependencies = {
-   ["minitel"] = ""
+   ["examnes-minitel"] = ""
   },
   postinstall = {
    "mtcfg --firstrun",
@@ -30,7 +30,7 @@
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["minitel-docs"] = {
+ ["examnes-minitel-docs"] = {
   files = {
    ["master/protocol-3.md"] = "/doc/minitel",
    ["master/protocol-4.md"] = "/doc/minitel",
@@ -45,44 +45,44 @@
   authors = "Izaya, Skye",
   repo = "tree/master/"
  },
- ["frequestd"] = {
+ ["examnes-frequestd"] = {
   files = {
    ["master/FRequest/OpenOS/etc/rc.d/fserv.lua"] = "//etc/rc.d"
   },
   dependencies = {
-   ["minitel"] = "",
-   ["libsyslog"] = ""
+   ["examnes-minitel"] = "",
+   ["examnes-libsyslog"] = ""
   },
   name = "FRequest Daemon",
   description = "Reasonably sane FRequest server",
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["fget"] = {
+ ["examnes-fget"] = {
   files = {
    ["master/FRequest/OpenOS/usr/bin/fget.lua"] = "/bin"
   },
   dependencies = {
-   ["minitel"] = ""
+   ["examnes-minitel"] = ""
   },
   name = "FGet",
   description = "Dumb-as-rocks FRequest client",
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["mmaild"] = {
+ ["examnes-mmaild"] = {
   files = {
    ["master/MMail/OpenOS/etc/rc.d/mmail.lua"] = "//etc/rc.d"
   },
   dependencies = {
-   ["minitel"] = ""
+   ["examnes-minitel"] = ""
   },
   name = "Minitel Mail Daemon",
   description = "Simple mail server, implementing maildir.",
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["vtunnel"] = {
+ ["examnes-vtunnel"] = {
   files = {
    ["master/vTunnel/interminitel.lua"] = "/lib",
    ["master/vTunnel/OpenOS/usr/man/vtunnel"] = "/man",
@@ -96,20 +96,20 @@
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["mmail-send"] = {
+ ["examnes-mmail-send"] = {
   files = {
    ["master/MMail/OpenOS/usr/bin/mmail-send.lua"] = "/bin",
    ["master/MMail/OpenOS/usr/man/mmail-send"] = "/man"
   },
   dependencies = {
-   ["minitel"] = ""
+   ["examnes-minitel"] = ""
   },
   name = "mmail-send",
   description = "Command line program for sending mail over the minitel network.",
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["libsyslog"] = {
+ ["examnes-libsyslog"] = {
   files = {
    ["master/syslog/OpenOS/usr/lib/syslog.lua"] = "/lib",
    ["master/syslog/OpenOS/usr/man/syslog"] = "/man",
@@ -119,7 +119,7 @@
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["syslogd"] = {
+ ["examnes-syslogd"] = {
   files = {
    ["master/syslog/OpenOS/etc/rc.d/syslogd.lua"] = "//etc/rc.d",
    ["master/syslog/OpenOS/usr/man/syslogd"] = "/man",
@@ -129,7 +129,7 @@
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["wolbeacon"] = {
+ ["examnes-wolbeacon"] = {
   files = {
    ["master/WoLBeacon/OpenOS/etc/rc.d/wolbeacon.lua"] = "//etc/rc.d",
    ["master/WoLBeacon/OpenOS/usr/man/wolbeacon"] = "/man",
@@ -139,7 +139,7 @@
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["realtime"] = {
+ ["examnes-realtime"] = {
   files = {
    ["master/realtime/OpenOS/usr/lib/realtime.lua"] = "/lib",
    ["master/realtime/OpenOS/usr/man/realtime"] = "/man",
@@ -149,7 +149,7 @@
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["realtime-sync"] = {
+ ["examnes-realtime-sync"] = {
   files = {
    ["master/realtime/OpenOS/etc/rc.d/realtime-sync.lua"] = "//etc/rc.d",
    ["master/realtime/OpenOS/usr/man/realtime-sync"] = "/man",
@@ -162,21 +162,21 @@
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["realtime-relay"] = {
+ ["examnes-realtime-relay"] = {
   files = {
    ["master/realtime/OpenOS/etc/rc.d/realtime-relay.lua"] = "//etc/rc.d",
    ["master/realtime/OpenOS/usr/man/realtime-relay"] = "/man",
   },
   dependencies = {
-   ["realtime"] = "",
-   ["minitel"] = ""
+   ["examnes-realtime"] = "",
+   ["examnes-minitel"] = ""
   },
   name = "realtime-relay",
   description = "Minitel-based real-time synchronisation daemon for OpenOS",
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["portinfo"] = {
+ ["examnes-portinfo"] = {
   files = {
    ["https://raw.githubusercontent.com/ShadowKatStudios/OC-ports/master/portinfo.lua"] = "/lib",
    ["https://raw.githubusercontent.com/ShadowKatStudios/OC-ports/master/oc.db"] = "/lib/ports",
@@ -187,7 +187,7 @@
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["mtrpc"] = {
+ ["examnes-mtrpc"] = {
   files = {
    ["master/RPC/OpenOS/usr/bin/importcomponent.lua"] = "/bin",
    ["master/RPC/OpenOS/usr/bin/exportcomponent.lua"] = "/bin",
@@ -195,7 +195,7 @@
    ["master/RPC/OpenOS/usr/man/rpc"] = "/man",
   },
   dependencies = {
-   ["minitel"] = "",
+   ["examnes-minitel"] = "",
    ["vcomponent"] = ""
   },
   name = "Minitel Remote Procedure Call",
@@ -203,21 +203,21 @@
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["mtfs"] = {
+ ["examnes-mtfs"] = {
   files = {
    ["master/MTFS/OpenOS/usr/bin/importfs.lua"] = "/bin",
    ["master/MTFS/OpenOS/usr/bin/exportfs.lua"] = "/bin",
    ["master/MTFS/OpenOS/usr/lib/fsproxy.lua"] = "/lib",
   },
   dependencies = {
-   ["mtrpc"] = ""
+   ["examnes-mtrpc"] = ""
   },
   name = "Minitel Remote Filesystem",
   description = "Utilities for accessing filesystems over Minitel RPC",
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["liblzss"] = {
+ ["examnes-liblzss"] = {
   files = {
    ["https://raw.githubusercontent.com/kieselsteini/lzss/master/lzss.lua"] = "/lib",
   },
@@ -227,19 +227,19 @@
   authors = "Sebastian Steinhauer (kieselsteini)",
   repo = "tree/master/"
  },
- ["liblz16"] = {
+ ["examnes-liblz16"] = {
   files = {
    ["https://git.shadowkat.net/izaya/OC-misc/raw/branch/master/lz16/liblz16.lua"] = "/lib",
   },
   dependencies = {
-   ["liblzss"] = "",
+   ["examnes-liblzss"] = "",
   },
   name = "LZ16 Library",
   description = "Stream compression library using LZSS",
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["libmtar"] = {
+ ["examnes-libmtar"] = {
   files = {
    ["https://git.shadowkat.net/izaya/OC-misc/src/branch/master/mtar/libmtar.lua"] = "/lib",
   },
@@ -249,13 +249,13 @@
   authors = "Izaya",
   repo = "tree/master/"
  },
- ["mtar"] = {
+ ["examnes-mtar"] = {
   files = {
    ["https://git.shadowkat.net/izaya/OC-misc/raw/branch/master/mtar/OpenOS/usr/bin/mtar.lua"] = "/lib",
    ["https://git.shadowkat.net/izaya/OC-misc/raw/branch/master/mtar/OpenOS/usr/man/mtar"] = "/man",
   },
   dependencies = {
-   ["libmtar"] = "",
+   ["examnes-libmtar"] = "",
   },
   name = "MiniTel ARchiver",
   description = "Dumb as rocks archiving utility",


### PR DESCRIPTION
This pull request fixes a bug I encountered when using the RPC library on multiple machines. An attempt to create a function handler on both machines caused the response containing the result of the function to be interpreted as a request to execute the function, which subsequently caused the function handler to send a "function unavailable" response, which was also interpreted as a function call on the other side. Ultimately, calling any function with this configuration resulted in an infinite loop.