### PR TITLE
ricad missing mtrpc as a dependency

### DIFF
--- a/programs.cfg
+++ b/programs.cfg
@@ -311,6 +311,7 @@
   files = {},
   dependencies = {
    ["https://git.shadowkat.net/izaya/PsychOSPackages/raw/branch/master/ricad/service/ricad.lua"] = "//etc/rc.d",
+   ["mtrpc"] = "",
   },
   name = "ricad",
   description = "Remote Internet Card Access (rica) server",


### PR DESCRIPTION
Found that when installing ricad on a computer that doesn't already have mtrpc installed it errors